### PR TITLE
Disk size override

### DIFF
--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -25,6 +25,7 @@ task arraycheck_classic {
 	input {
 		Array[File] test
 		Array[File] truth
+		Int? disk_size_override
 		Boolean fastfail = false  # should we exit out upon first mismatch?
 		Boolean rdata_check = false  # check with all.equal() upon failure; only use with RData files!
 		Float tolerance = 0.00000001  # tolerance to use for all.equal(); default is 1.0E-8
@@ -32,7 +33,8 @@ task arraycheck_classic {
 
 	Int test_size = ceil(size(test, "GB"))
 	Int truth_size = ceil(size(truth, "GB"))
-	Int finalDiskSize = test_size + truth_size + 3
+	Int additive_size = test_size + truth_size + 3
+	Int finalDiskSize = select_first([disk_size_override, additive_size])
 
 	command <<<
 	failed_at_least_once="false"

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -25,16 +25,13 @@ task arraycheck_classic {
 	input {
 		Array[File] test
 		Array[File] truth
-		Int? disk_size_override
+		Int disk_size_override
 		Boolean fastfail = false  # should we exit out upon first mismatch?
 		Boolean rdata_check = false  # check with all.equal() upon failure; only use with RData files!
 		Float tolerance = 0.00000001  # tolerance to use for all.equal(); default is 1.0E-8
 	}
 
-	Int test_size = ceil(size(test, "GB"))
-	Int truth_size = ceil(size(truth, "GB"))
-	Int additive_size = test_size + truth_size + 3
-	Int finalDiskSize = select_first([disk_size_override, additive_size])
+	Int finalDiskSize = disk_size_override
 
 	command <<<
 	failed_at_least_once="false"


### PR DESCRIPTION
I'm pretty sure my logic was that size() doesn't work on arrays, [per the 1.0 spec](https://github.com/openwdl/wdl/blob/legacy/versions/1.0/SPEC.md#float-sizefile-string). Currently, my logic is moreso "you should know the size of your truth files, dude!"